### PR TITLE
API 6611 loma linda its part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ For example,
 # Observation
 
 ![observation-components](vista-fhir-query/src/plantuml/observation-components.png)
+
+
+# Testing
+`vista-fhir-query-tests` provides the integration test suite that can be ran locally. It will automatically start Mock services.
+Some tests are require connectivity to authentication services and can be enabled by setting additional system properties.
+Additionally, this secrets can be defined in the file `vista-fhir-query-tests/config/secrets.properties`, for example:
+
+```
+access-token=not-used
+system-oauth-robot.aud=https://deptva-eval.okta.com/oauth2/1234567890/v1/token
+system-oauth-robot.token-url=https://sandbox-api.va.gov/oauth2/health-insurance/v1/token
+system-oauth-robot.client-id=1234567890
+system-oauth-robot.client-secret=SECRETSECRETIVEGOTASECRET
+```

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>7.0.23</version>
+    <version>7.0.24</version>
   </parent>
   <artifactId>vista-fhir-query-parent</artifactId>
   <version>0.0.79-SNAPSHOT</version>

--- a/vista-fhir-query-ids-mapping/pom.xml
+++ b/vista-fhir-query-ids-mapping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>7.0.23</version>
+    <version>7.0.24</version>
     <relativePath/>
   </parent>
   <artifactId>vista-fhir-query-ids-mapping</artifactId>

--- a/vista-fhir-query-mock-services/pom.xml
+++ b/vista-fhir-query-mock-services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>7.0.23</version>
+    <version>7.0.24</version>
     <relativePath/>
   </parent>
   <artifactId>vista-fhir-query-mock-services</artifactId>

--- a/vista-fhir-query-tests/config/.gitignore
+++ b/vista-fhir-query-tests/config/.gitignore
@@ -1,0 +1,1 @@
+*.properties*

--- a/vista-fhir-query-tests/local-docker-image
+++ b/vista-fhir-query-tests/local-docker-image
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+
+
+usage() {
+cat<<EOF
+$0 <build|run> [run-args]
+
+Build or run the integration test docker image.
+
+EOF
+}
+
+build() {
+  mvn clean deploy \
+    -DskipTests \
+    -Dexec.skip=true \
+    -Dsentinel.skipLaunch=true \
+    -P'!standard' \
+    -Prelease \
+    -Ddocker.skip.push=true \
+    -Dmaven.deploy.skip=true \
+    -Ddocker.username=$DOCKER_USERNAME \
+    -Ddocker.password="$DOCKER_PASSWORD"
+}
+
+
+run() {
+  case $(uname) in
+    Darwin) THIS_MACHINE="docker.for.mac.localhost";;
+    Linux) THIS_MACHINE="localhost";;
+    *) echo "Add support for your operating system: $(uname)"; exit 1;;
+  esac
+  local secrets=config/secrets.conf
+  if [ -f "${secrets}" ]; then SECRETS_OPTION="--env-file=${secrets}"; fi
+  docker run \
+    --rm \
+    --network="host" \
+    ${SECRETS_OPTION:-} \
+    -e K8S_LOAD_BALANCER=$THIS_MACHINE \
+    -e VFQ_URL=http://$THIS_MACHINE:8095 \
+    -e K8S_ENVIRONMENT=${ENV:-local} \
+    -e SENTINEL_ENV=${ENV:-local} \
+    -e CLIENT_KEY="${CLIENT_KEY:-hello}" \
+     vasdvp/health-apis-vista-fhir-query-tests:latest $@
+}
+
+main() {
+  local cmd=$1
+  shift
+  case "$cmd" in
+    r|run) run $@;;
+    b|build) build;;
+    br) build && run $@;;
+    *) usage "Unknown command $cmd"
+  esac
+}
+
+
+main $@

--- a/vista-fhir-query-tests/pom.xml
+++ b/vista-fhir-query-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>7.0.23</version>
+    <version>7.0.24</version>
     <relativePath/>
   </parent>
   <artifactId>vista-fhir-query-tests</artifactId>

--- a/vista-fhir-query-tests/src/main/docker/entrypoint.sh
+++ b/vista-fhir-query-tests/src/main/docker/entrypoint.sh
@@ -24,6 +24,10 @@ main() {
   if [ -n "${VFQ_R4_PORT:-}" ]; then addToSystemProperties "sentinel.r4.port" "${VFQ_R4_PORT}"; fi
   if [ -n "${MAGIC_ACCESS_TOKEN:-}" ]; then addToSystemProperties "access-token" "${MAGIC_ACCESS_TOKEN}"; fi
   if [ -n "${VFQ_CLIENT_KEY:-}" ]; then addToSystemProperties "client-key" "${VFQ_CLIENT_KEY}"; fi
+  if [ -n "${SYSTEM_OAUTH_ROBOT_AUD:-}" ]; then addToSystemProperties "system-oauth-robot.aud" "${SYSTEM_OAUTH_ROBOT_AUD}"; fi
+  if [ -n "${SYSTEM_OAUTH_ROBOT_TOKEN_URL:-}" ]; then addToSystemProperties "system-oauth-robot.token-url" "${SYSTEM_OAUTH_ROBOT_TOKEN_URL}"; fi
+  if [ -n "${SYSTEM_OAUTH_ROBOT_CLIENT_ID:-}" ]; then addToSystemProperties "system-oauth-robot.client-id" "${SYSTEM_OAUTH_ROBOT_CLIENT_ID}"; fi
+  if [ -n "${SYSTEM_OAUTH_ROBOT_CLIENT_SECRET:-}" ]; then addToSystemProperties "system-oauth-robot.client-secret" "${SYSTEM_OAUTH_ROBOT_CLIENT_SECRET}"; fi
 
   java-tests \
     --module-name "vista-fhir-query-tests" \

--- a/vista-fhir-query-tests/src/main/docker/entrypoint.sh
+++ b/vista-fhir-query-tests/src/main/docker/entrypoint.sh
@@ -28,6 +28,7 @@ main() {
   if [ -n "${SYSTEM_OAUTH_ROBOT_TOKEN_URL:-}" ]; then addToSystemProperties "system-oauth-robot.token-url" "${SYSTEM_OAUTH_ROBOT_TOKEN_URL}"; fi
   if [ -n "${SYSTEM_OAUTH_ROBOT_CLIENT_ID:-}" ]; then addToSystemProperties "system-oauth-robot.client-id" "${SYSTEM_OAUTH_ROBOT_CLIENT_ID}"; fi
   if [ -n "${SYSTEM_OAUTH_ROBOT_CLIENT_SECRET:-}" ]; then addToSystemProperties "system-oauth-robot.client-secret" "${SYSTEM_OAUTH_ROBOT_CLIENT_SECRET}"; fi
+  if [ -n "${VISTA_CONNECTIVITY_ICN_AT_SITES:-}" ]; then addToSystemProperties "vista-connectivity.icn-at-sites" "${VISTA_CONNECTIVITY_ICN_AT_SITES}"; fi
 
   java-tests \
     --module-name "vista-fhir-query-tests" \

--- a/vista-fhir-query-tests/src/main/java/gov/va/api/health/vistafhirquery/tests/TestIds.java
+++ b/vista-fhir-query-tests/src/main/java/gov/va/api/health/vistafhirquery/tests/TestIds.java
@@ -1,14 +1,82 @@
 package gov.va.api.health.vistafhirquery.tests;
 
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.NonNull;
 import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
 
 @Value
 @Builder(toBuilder = true)
 public final class TestIds {
   @NonNull String observationVitalSign;
+
   @NonNull String observationLaboratory;
+
   @NonNull String patient;
+
   @Builder.Default String unknown = "5555555555555";
+
+  @Default @NonNull List<IcnAtSites> patientSites = new ArrayList<>();
+
+  @Value
+  @Builder
+  public static class IcnAtSites {
+    @NonNull String icn;
+
+    @Default @NonNull List<String> vistas = new ArrayList<>();
+
+    private static IllegalArgumentException badFormat(String badIcnAtSite) {
+      return new IllegalArgumentException(
+          "Expected icn@site[+site][...], e.g. 123456789V123456@673+605, got " + badIcnAtSite);
+    }
+
+    /**
+     * Parse a CSV of ICN @ Site (see `of` for more details).
+     *
+     * <p>Example: 999@123,888@456+789,777@789
+     */
+    public static List<IcnAtSites> csvOf(String icnAtSiteCsv) {
+      if (isBlank(icnAtSiteCsv)) {
+        return List.of();
+      }
+      return Arrays.stream(icnAtSiteCsv.split(",+", -1))
+          .filter(StringUtils::isNotBlank)
+          .map(IcnAtSites::of)
+          .collect(toList());
+    }
+
+    /**
+     * Parse the ICN @ Site string into an object representation. Format is:
+     * ${icn}@${site}[+${site}][...]
+     *
+     * <p>Examples: 999@123, 999@123+456
+     *
+     * <p>Use `+` to specify multiple sites. Leading, trailing, and repeating `+` are ignored, e.g.
+     * 999@++123++456++ is equal to 999@123+456 or ICN 999 at sites 123 and 456
+     */
+    public static IcnAtSites of(String icnAtSite) {
+      if (isBlank(icnAtSite)) {
+        throw badFormat(icnAtSite);
+      }
+      int at = icnAtSite.indexOf('@');
+      if (at < 1 || at > icnAtSite.length() - 2) {
+        throw badFormat(icnAtSite);
+      }
+      String icn = icnAtSite.substring(0, at);
+      String sites = icnAtSite.substring(at + 1);
+      List<String> vistas =
+          List.of(sites.replaceFirst("^\\++", "").replaceFirst("\\++$", "").split("\\++", -1));
+      if (vistas.isEmpty()) {
+        throw badFormat(icnAtSite);
+      }
+      return IcnAtSites.builder().icn(icn).vistas(vistas).build();
+    }
+  }
 }

--- a/vista-fhir-query-tests/src/main/java/gov/va/api/health/vistafhirquery/tests/TestIds.java
+++ b/vista-fhir-query-tests/src/main/java/gov/va/api/health/vistafhirquery/tests/TestIds.java
@@ -21,7 +21,7 @@ public final class TestIds {
 
   @NonNull String patient;
 
-  @Builder.Default String unknown = "5555555555555";
+  @Default String unknown = "5555555555555";
 
   @Default @NonNull List<IcnAtSites> patientSites = new ArrayList<>();
 

--- a/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/TestIdsTest.java
+++ b/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/TestIdsTest.java
@@ -1,0 +1,81 @@
+package gov.va.api.health.vistafhirquery.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import gov.va.api.health.vistafhirquery.tests.TestIds.IcnAtSites;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TestIdsTest {
+  static Stream<Arguments> icnAtSiteCsvOf() {
+    return Stream.of(
+        arguments((String) null, List.of()),
+        arguments("", List.of()),
+        arguments(",,,", List.of()),
+        arguments(
+            "999@123", List.of(IcnAtSites.builder().icn("999").vistas(List.of("123")).build())),
+        arguments(
+            "999@123,888@456+789,777@789",
+            List.of(
+                IcnAtSites.builder().icn("999").vistas(List.of("123")).build(),
+                IcnAtSites.builder().icn("888").vistas(List.of("456", "789")).build(),
+                IcnAtSites.builder().icn("777").vistas(List.of("789")).build())),
+        arguments(
+            ",,999@123,,888@456,,",
+            List.of(
+                IcnAtSites.builder().icn("999").vistas(List.of("123")).build(),
+                IcnAtSites.builder().icn("888").vistas(List.of("456")).build())));
+  }
+
+  static Stream<Arguments> icnAtSiteOf() {
+    return Stream.of(
+        arguments(
+            "1234567890V123456@123",
+            IcnAtSites.builder().icn("1234567890V123456").vistas(List.of("123")).build()),
+        arguments(
+            "1234567890@123+456",
+            IcnAtSites.builder().icn("1234567890").vistas(List.of("123", "456")).build()),
+        arguments(
+            "1234567890@++123++456++",
+            IcnAtSites.builder().icn("1234567890").vistas(List.of("123", "456")).build()),
+        arguments(
+            "1234567890V123456@123+456+789",
+            IcnAtSites.builder()
+                .icn("1234567890V123456")
+                .vistas(List.of("123", "456", "789"))
+                .build()));
+  }
+
+  static Stream<Arguments> icnAtSiteOfThrowsExceptionForBadString() {
+    return Stream.of(
+        arguments(""),
+        arguments((String) null),
+        arguments("1234567890V123456"),
+        arguments("1234567890V123456@"),
+        arguments("@123"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void icnAtSiteCsvOf(String icnAtSiteCsv, List<IcnAtSites> expected) {
+    assertThat(IcnAtSites.csvOf(icnAtSiteCsv)).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void icnAtSiteOf(String icnAtSite, IcnAtSites expected) {
+    assertThat(IcnAtSites.of(icnAtSite)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void icnAtSiteOfThrowsExceptionForBadString(String icnAtSite) {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> IcnAtSites.of(icnAtSite));
+  }
+}

--- a/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/VistaConnectivityIT.java
+++ b/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/VistaConnectivityIT.java
@@ -1,0 +1,53 @@
+package gov.va.api.health.vistafhirquery.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import gov.va.api.health.r4.api.resources.Observation;
+import gov.va.api.health.sentinel.AccessTokens;
+import gov.va.api.health.sentinel.ExpectedResponse;
+import io.restassured.RestAssured;
+import io.restassured.http.Method;
+import io.restassured.specification.RequestSpecification;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class VistaConnectivityIT {
+
+  private static String token;
+
+  static Stream<Arguments> connected() {
+    return Stream.of(
+        arguments("tampa", "1011537977V693883"),
+        arguments("also tampa", "1017283148V813263"),
+        arguments("also also tampa", "1011537977V693883"));
+  }
+
+  @BeforeAll
+  static void acquireToken() {
+    token = AccessTokens.get().forSystemScopes("system/Observation.read");
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void connected(String intendedSite, String icn) {
+    var sd = SystemDefinitions.systemDefinition().r4();
+    RequestSpecification request =
+        RestAssured.given()
+            .baseUri(sd.url())
+            .port(sd.port())
+            .relaxedHTTPSValidation()
+            .headers(Map.of("Authorization", "Bearer " + token))
+            .contentType("application/json")
+            .accept("application/json");
+    ExpectedResponse response =
+        ExpectedResponse.of(
+            request.request(Method.GET, sd.apiPath() + "Observation?patient={icn}", icn));
+    var bundle = response.expect(200).expectValid(Observation.Bundle.class);
+    assertThat(bundle.total()).isGreaterThan(0);
+  }
+}

--- a/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/VistaConnectivityIT.java
+++ b/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/VistaConnectivityIT.java
@@ -1,40 +1,62 @@
 package gov.va.api.health.vistafhirquery.tests;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import gov.va.api.health.r4.api.resources.Observation;
 import gov.va.api.health.sentinel.AccessTokens;
 import gov.va.api.health.sentinel.ExpectedResponse;
+import gov.va.api.health.vistafhirquery.tests.TestIds.IcnAtSites;
 import io.restassured.RestAssured;
 import io.restassured.http.Method;
 import io.restassured.specification.RequestSpecification;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@Slf4j
 public class VistaConnectivityIT {
-
   private static String token;
-
-  static Stream<Arguments> connected() {
-    return Stream.of(
-        arguments("tampa", "1011537977V693883"),
-        arguments("also tampa", "1017283148V813263"),
-        arguments("also also tampa", "1011537977V693883"));
-  }
 
   @BeforeAll
   static void acquireToken() {
+    assumeSystemAccessTokenIsPossible();
     token = AccessTokens.get().forSystemScopes("system/Observation.read");
+  }
+
+  private static void assumeSystemAccessTokenIsPossible() {
+    SystemDefinitions.loadConfigSecretsProperties();
+    for (var property :
+        List.of(
+            "system-oauth-robot.aud",
+            "system-oauth-robot.token-url",
+            "system-oauth-robot.client-id",
+            "system-oauth-robot.client-secret")) {
+
+      String value = System.getProperty(property);
+      if (isBlank(value)) {
+        log.info("Missing property {}", property);
+      }
+      assumeThat(value)
+          .as("System access token cannot be created: Missing property: %s", property)
+          .isNotBlank();
+    }
+  }
+
+  static Stream<Arguments> connected() {
+    return SystemDefinitions.systemDefinition().publicIds().patientSites().stream()
+        .map(Arguments::of);
   }
 
   @ParameterizedTest
   @MethodSource
-  void connected(String intendedSite, String icn) {
+  void connected(IcnAtSites icnAtSites) {
     var sd = SystemDefinitions.systemDefinition().r4();
     RequestSpecification request =
         RestAssured.given()
@@ -46,7 +68,8 @@ public class VistaConnectivityIT {
             .accept("application/json");
     ExpectedResponse response =
         ExpectedResponse.of(
-            request.request(Method.GET, sd.apiPath() + "Observation?patient={icn}", icn));
+            request.request(
+                Method.GET, sd.apiPath() + "Observation?patient={icn}", icnAtSites.icn()));
     var bundle = response.expect(200).expectValid(Observation.Bundle.class);
     assertThat(bundle.total()).isGreaterThan(0);
   }

--- a/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/VistaConnectivityIT.java
+++ b/vista-fhir-query-tests/src/test/java/gov/va/api/health/vistafhirquery/tests/VistaConnectivityIT.java
@@ -1,11 +1,13 @@
 package gov.va.api.health.vistafhirquery.tests;
 
+import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import gov.va.api.health.r4.api.resources.Observation;
 import gov.va.api.health.sentinel.AccessTokens;
+import gov.va.api.health.sentinel.Environment;
 import gov.va.api.health.sentinel.ExpectedResponse;
 import gov.va.api.health.vistafhirquery.tests.TestIds.IcnAtSites;
 import io.restassured.RestAssured;
@@ -57,6 +59,7 @@ public class VistaConnectivityIT {
   @ParameterizedTest
   @MethodSource
   void connected(IcnAtSites icnAtSites) {
+    assumeEnvironmentNotIn(Environment.STAGING, Environment.PROD);
     var sd = SystemDefinitions.systemDefinition().r4();
     RequestSpecification request =
         RestAssured.given()

--- a/vista-fhir-query/pom.xml
+++ b/vista-fhir-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>7.0.23</version>
+    <version>7.0.24</version>
     <relativePath/>
   </parent>
   <artifactId>vista-fhir-query</artifactId>

--- a/vista-fhir-query/src/main/resources/application.properties
+++ b/vista-fhir-query/src/main/resources/application.properties
@@ -1,5 +1,10 @@
 server.port=8095
 
+# Logging
+logging.stack-trace-filter=java.base,java.lang.reflect.Method, org.apache.coyote, org.apache.catalina, org.apache.tomcat, org.springframework.aop, org.springframework.security, org.springframework.transaction, org.springframework.web, org.springframework.cglib, org.springframework.validation.beanvalidation, org.springframework.boot.actuate, javax.servlet.http,  reactor.core, reactor.ipc, sun.reflect, net.sf.cglib, ByCGLIB, io.netty
+logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx{full,${logging.stack-trace-filter}}}
+
+
 # Identity Service Client Configs
 ids-client.patient-icn.enabled=true
 ids-client.patient-icn.id-pattern=unset


### PR DESCRIPTION
- Latest version of parent
- working test with hard coded ICNs/Vista
- Support for configurable Vista ICNs/Site combinations used for connectivity IT tests. Support for secret system properties to specified as a file.
- vista-fhir-query-tests/config/.gitignore for system properties
- Testing notes updates in README
- local-docker-image utility this will use vista-fhir-query-tests/config/secrets.conf
