### PR TITLE
API-8127-coverage-transformer

### DIFF
--- a/vista-fhir-query/pom.xml
+++ b/vista-fhir-query/pom.xml
@@ -11,7 +11,7 @@
   <version>1.0.10-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <charon.version>4.0.7</charon.version>
+    <charon.version>4.0.8</charon.version>
     <fhir-resources.version>7.0.7</fhir-resources.version>
     <jacoco.coverage>0.94</jacoco.coverage>
     <mssql-jdbc.version>9.2.1.jre15</mssql-jdbc.version>

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
+import lombok.NonNull;
 
 @Builder
 public class R4CoverageTransformer {
@@ -37,9 +38,9 @@ public class R4CoverageTransformer {
           "HIPAA G8 OTHER RELATIONSHIP",
           codeAndDisplay("other", "Other"));
 
-  Map.Entry<String, GetInsRpcResults> rpcResult;
+  @NonNull Map.Entry<String, GetInsRpcResults> rpcResult;
 
-  String patientIcn;
+  @NonNull String patientIcn;
 
   private static Coding codeAndDisplay(String code, String display) {
     return Coding.builder().code(code).display(display).build();
@@ -132,10 +133,11 @@ public class R4CoverageTransformer {
       return null;
     }
     // ToDo this needs more parts for easier identification
+    // ToDo needs to be uniform across vista sites
     return List.of(
         Reference.builder()
             .reference(
-                "Coverage/"
+                "Organization/"
                     + rpcResult.getValue().insTypeInsuranceType().internalValueRepresentation())
             .build());
   }
@@ -188,6 +190,7 @@ public class R4CoverageTransformer {
   /** Transform an RPC response to fhir. */
   public Coverage toFhir() {
     return Coverage.builder()
+        .id(patientIcn + "^" + rpcResult.getKey())
         .extension(extensions())
         .status(Coverage.Status.active)
         .subscriberId(subscriberId())

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
@@ -161,6 +161,7 @@ public class R4CoverageTransformer {
   public Coverage toFhir() {
     return Coverage.builder()
         .extension(extensions())
+        .status(Coverage.Status.active)
         .subscriberId(subscriberId())
         .relationship(relationship())
         .period(period())

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
@@ -38,8 +38,17 @@ public class R4CoverageTransformer {
 
   GetInsRpcResults vista;
 
+  String patientIcn;
+
   private static Coding codeAndDisplay(String code, String display) {
     return Coding.builder().code(code).display(display).build();
+  }
+
+  private Reference beneficiary() {
+    if (isBlank(patientIcn)) {
+      return null;
+    }
+    return Reference.builder().reference("Patient/" + patientIcn).build();
   }
 
   private List<Coverage.CoverageClass> classes() {
@@ -82,7 +91,7 @@ public class R4CoverageTransformer {
       extensions.add(
           Extension.builder()
               .url("http://va.gov/fhir/StructureDefinition/coverage-stopPolicyFromBilling")
-              .valueCodeableConcept(
+              .valueBoolean(
                   yesNo(vista.insTypeStopPolicyFromBilling().internalValueRepresentation()))
               .build());
     }
@@ -163,6 +172,7 @@ public class R4CoverageTransformer {
         .extension(extensions())
         .status(Coverage.Status.active)
         .subscriberId(subscriberId())
+        .beneficiary(beneficiary())
         .relationship(relationship())
         .period(period())
         .payor(payors())
@@ -171,17 +181,12 @@ public class R4CoverageTransformer {
         .build();
   }
 
-  private CodeableConcept yesNo(String zeroOrOne) {
-    String yesNoSystem = "http://terminology.hl7.org/ValueSet/v2-0136";
+  private boolean yesNo(String zeroOrOne) {
     switch (zeroOrOne) {
       case "0":
-        return CodeableConcept.builder()
-            .coding(List.of(Coding.builder().system(yesNoSystem).code("N").display("No").build()))
-            .build();
+        return false;
       case "1":
-        return CodeableConcept.builder()
-            .coding(List.of(Coding.builder().system(yesNoSystem).code("Y").display("Yes").build()))
-            .build();
+        return true;
       default:
         throw new IllegalArgumentException("Unknown Yes/No code: " + zeroOrOne);
     }

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
@@ -1,0 +1,124 @@
+package gov.va.api.health.vistafhirquery.service.controller.coverage;
+
+import static gov.va.api.health.vistafhirquery.service.controller.R4Transformers.allBlank;
+import static gov.va.api.health.vistafhirquery.service.controller.R4Transformers.isBlank;
+
+import gov.va.api.health.r4.api.datatypes.CodeableConcept;
+import gov.va.api.health.r4.api.datatypes.Coding;
+import gov.va.api.health.r4.api.datatypes.Period;
+import gov.va.api.health.r4.api.elements.Extension;
+import gov.va.api.health.r4.api.elements.Reference;
+import gov.va.api.health.r4.api.resources.Coverage;
+import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsRpcResults;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public class R4CoverageTransformer {
+  GetInsRpcResults vista;
+
+  private List<Coverage.CoverageClass> classes() {
+    if (isBlank(vista.insTypeGroupPlan())) {
+      return null;
+    }
+    return List.of(
+        Coverage.CoverageClass.builder()
+            .value(vista.insTypeGroupPlan().externalValueRepresentation())
+            .type(
+                CodeableConcept.builder()
+                    .coding(
+                        List.of(
+                            Coding.builder()
+                                .system("http://terminology.hl7.org/CodeSystem/coverage-class")
+                                .code("group")
+                                .build()))
+                    .build())
+            .build());
+  }
+
+  private List<Extension> extensions() {
+    List<Extension> extensions = new ArrayList<>();
+    if (!isBlank(vista.insTypePharmacyPersonCode())) {
+      // ToDo update url
+      // ToDo if parse int fails, don't add?
+      extensions.add(
+          Extension.builder()
+              .url("http://va.gov/fhir/StructureDefinition/coverage-pharmacyPersonCode")
+              .valueInteger(
+                  Integer.parseInt(vista.insTypePharmacyPersonCode().externalValueRepresentation()))
+              .build());
+    }
+    if (extensions.isEmpty()) {
+      return null;
+    }
+    return extensions;
+  }
+
+  private Integer order() {
+    if (isBlank(vista.insTypeCoordinationOfBenefits())) {
+      return null;
+    }
+    // ToDo if number can't be parsed, log and return null?
+    return Integer.parseInt(vista.insTypeCoordinationOfBenefits().externalValueRepresentation());
+  }
+
+  private List<Reference> payors() {
+    if (isBlank(vista.insTypeInsuranceType())) {
+      return null;
+    }
+    // ToDo this needs more parts that can be identified
+    return List.of(
+        Reference.builder()
+            .reference("Coverage/" + vista.insTypeInsuranceType().internalValueRepresentation())
+            .build());
+  }
+
+  private Period period() {
+    Period period = Period.builder().build();
+    if (!isBlank(vista.insTypeEffectiveDateOfPolicy())) {
+      period.start(vista.insTypeEffectiveDateOfPolicy().externalValueRepresentation());
+    }
+    if (!isBlank(vista.insTypeInsuranceExpirationDate())) {
+      period.end(vista.insTypeInsuranceExpirationDate().externalValueRepresentation());
+    }
+    if (allBlank(period.start(), period.end())) {
+      return null;
+    }
+    return period;
+  }
+
+  private CodeableConcept relationship() {
+    if (isBlank(vista.insTypePtRelationshipHipaa())) {
+      return null;
+    }
+    // ToDo map code
+    return CodeableConcept.builder()
+        .coding(
+            List.of(
+                Coding.builder()
+                    .system("http://terminology.hl7.org/CodeSystem/subscriber-relationship")
+                    .build()))
+        .build();
+  }
+
+  private String subscriberId() {
+    if (isBlank(vista.insTypeSubscriberId())) {
+      return null;
+    }
+    return vista.insTypeSubscriberId().externalValueRepresentation();
+  }
+
+  /** Transform an RPC response to fhir. */
+  public Coverage toFhir() {
+    return Coverage.builder()
+        .extension(extensions())
+        .subscriberId(subscriberId())
+        .relationship(relationship())
+        .period(period())
+        .payor(payors())
+        .coverageClass(classes())
+        .order(order())
+        .build();
+  }
+}

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformer.java
@@ -9,6 +9,7 @@ import gov.va.api.health.r4.api.datatypes.Period;
 import gov.va.api.health.r4.api.elements.Extension;
 import gov.va.api.health.r4.api.elements.Reference;
 import gov.va.api.health.r4.api.resources.Coverage;
+import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsEntry;
 import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsRpcResults;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +53,7 @@ public class R4CoverageTransformer {
   }
 
   private List<Coverage.CoverageClass> classes() {
-    if (isBlank(rpcResult.getValue().insTypeGroupPlan())) {
+    if (isEntryBlank(rpcResult.getValue().insTypeGroupPlan())) {
       return null;
     }
     return List.of(
@@ -73,7 +74,7 @@ public class R4CoverageTransformer {
   private List<Extension> extensions() {
     // ToDo update urls (needs to substitute host/base-path per env)
     List<Extension> extensions = new ArrayList<>();
-    if (!isBlank(rpcResult.getValue().insTypePharmacyPersonCode())) {
+    if (!isEntryBlank(rpcResult.getValue().insTypePharmacyPersonCode())) {
       try {
         extensions.add(
             Extension.builder()
@@ -90,7 +91,7 @@ public class R4CoverageTransformer {
             "Bad VistA pharmacy person code: " + rpcResult.getValue().insTypePharmacyPersonCode());
       }
     }
-    if (!isBlank(rpcResult.getValue().insTypeStopPolicyFromBilling())) {
+    if (!isEntryBlank(rpcResult.getValue().insTypeStopPolicyFromBilling())) {
       extensions.add(
           Extension.builder()
               .url("http://va.gov/fhir/StructureDefinition/coverage-stopPolicyFromBilling")
@@ -108,8 +109,12 @@ public class R4CoverageTransformer {
     return extensions;
   }
 
+  private boolean isEntryBlank(GetInsEntry insEntry) {
+    return isBlank(insEntry) || isBlank(insEntry.internalValueRepresentation());
+  }
+
   private Integer order() {
-    if (isBlank(rpcResult.getValue().insTypeCoordinationOfBenefits())) {
+    if (isEntryBlank(rpcResult.getValue().insTypeCoordinationOfBenefits())) {
       return null;
     }
     try {
@@ -123,7 +128,7 @@ public class R4CoverageTransformer {
   }
 
   private List<Reference> payors() {
-    if (isBlank(rpcResult.getValue().insTypeInsuranceType())) {
+    if (isEntryBlank(rpcResult.getValue().insTypeInsuranceType())) {
       return null;
     }
     // ToDo this needs more parts for easier identification
@@ -137,11 +142,11 @@ public class R4CoverageTransformer {
 
   private Period period() {
     Period period = Period.builder().build();
-    if (!isBlank(rpcResult.getValue().insTypeEffectiveDateOfPolicy())) {
+    if (!isEntryBlank(rpcResult.getValue().insTypeEffectiveDateOfPolicy())) {
       period.start(
           rpcResult.getValue().insTypeEffectiveDateOfPolicy().externalValueRepresentation());
     }
-    if (!isBlank(rpcResult.getValue().insTypeInsuranceExpirationDate())) {
+    if (!isEntryBlank(rpcResult.getValue().insTypeInsuranceExpirationDate())) {
       period.end(
           rpcResult.getValue().insTypeInsuranceExpirationDate().externalValueRepresentation());
     }
@@ -152,7 +157,7 @@ public class R4CoverageTransformer {
   }
 
   private CodeableConcept relationship() {
-    if (isBlank(rpcResult.getValue().insTypePtRelationshipHipaa())) {
+    if (isEntryBlank(rpcResult.getValue().insTypePtRelationshipHipaa())) {
       return null;
     }
     var fhirTerm =
@@ -174,7 +179,7 @@ public class R4CoverageTransformer {
   }
 
   private String subscriberId() {
-    if (isBlank(rpcResult.getValue().insTypeSubscriberId())) {
+    if (isEntryBlank(rpcResult.getValue().insTypeSubscriberId())) {
       return null;
     }
     return rpcResult.getValue().insTypeSubscriberId().externalValueRepresentation();

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/CoverageSamples.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/CoverageSamples.java
@@ -1,0 +1,113 @@
+package gov.va.api.health.vistafhirquery.service.controller.coverage;
+
+import gov.va.api.health.r4.api.datatypes.CodeableConcept;
+import gov.va.api.health.r4.api.datatypes.Coding;
+import gov.va.api.health.r4.api.datatypes.Period;
+import gov.va.api.health.r4.api.elements.Extension;
+import gov.va.api.health.r4.api.elements.Reference;
+import gov.va.api.health.r4.api.resources.Coverage;
+import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsEntry;
+import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsRpcResults;
+import java.util.List;
+import lombok.NoArgsConstructor;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class CoverageSamples {
+  @NoArgsConstructor(staticName = "create")
+  public static class VistaIblhsGetInsRpc {
+    private GetInsEntry entry(String fieldNumber, String internalRep, String externalRep) {
+      return GetInsEntry.builder()
+          .fileNumber("2.312")
+          .ien("1")
+          .fieldNumber(fieldNumber)
+          .internalValueRepresentation(internalRep)
+          .externalValueRepresentation(externalRep)
+          .build();
+    }
+
+    GetInsRpcResults getInsResults() {
+      return GetInsRpcResults.builder()
+          .insTypeInsuranceType(entry(".01", "TYPE", "type"))
+          .insTypeGroupPlan(entry(".18", "12345", "12345"))
+          .insTypeCoordinationOfBenefits(entry(".2", "1", "1"))
+          .insTypeSendBillToEmployer(entry("2.01", "0", "0"))
+          .insTypeEsghp(entry("2.1", "3", "3"))
+          .insTypeInsuranceExpirationDate(entry("3", "3210621.1542", "2021-06-21T15:42:00Z"))
+          .insTypeStopPolicyFromBilling(entry("3.04", "1", "1"))
+          .insTypePtRelationshipHipaa(
+              entry("4.03", "HIPAA 53 LIFE PARTNER", "HIPAA 53 LIFE PARTNER"))
+          .insTypePharmacyPersonCode(entry("4.06", "67890", "67890"))
+          .insTypePatientId(entry("5.01", "13579", "13579"))
+          .insTypeSubscriberId(entry("7.02", "24680", "24680"))
+          .insTypeEffectiveDateOfPolicy(entry("8", "3210120.2136", "2021-01-20T21:36:00Z"))
+          .build();
+    }
+  }
+
+  @NoArgsConstructor(staticName = "create")
+  public static class R4 {
+    private List<Coverage.CoverageClass> classes() {
+      return List.of(
+          Coverage.CoverageClass.builder()
+              .value("12345")
+              .type(
+                  CodeableConcept.builder()
+                      .coding(
+                          List.of(
+                              Coding.builder()
+                                  .system("http://terminology.hl7.org/CodeSystem/coverage-class")
+                                  .code("group")
+                                  .build()))
+                      .build())
+              .build());
+    }
+
+    Coverage coverage() {
+      return coverage("666", "1010101010V666666");
+    }
+
+    Coverage coverage(String station, String patient) {
+      return Coverage.builder()
+          .id(patient + "^" + station)
+          .extension(extensions())
+          .status(Coverage.Status.active)
+          .subscriberId("24680")
+          .beneficiary(Reference.builder().reference("Patient/" + patient).build())
+          .relationship(relationship())
+          .period(period())
+          .payor(List.of(Reference.builder().reference("Organization/TYPE").build()))
+          .coverageClass(classes())
+          .order(1)
+          .build();
+    }
+
+    private List<Extension> extensions() {
+      return List.of(
+          Extension.builder()
+              .url("http://va.gov/fhir/StructureDefinition/coverage-pharmacyPersonCode")
+              .valueInteger(67890)
+              .build(),
+          Extension.builder()
+              .url("http://va.gov/fhir/StructureDefinition/coverage-stopPolicyFromBilling")
+              .valueBoolean(true)
+              .build());
+    }
+
+    private Period period() {
+      return Period.builder().start("2021-01-20T21:36:00Z").end("2021-06-21T15:42:00Z").build();
+    }
+
+    private CodeableConcept relationship() {
+      return CodeableConcept.builder()
+          .coding(
+              List.of(
+                  Coding.builder()
+                      .system("http://terminology.hl7.org/CodeSystem/subscriber-relationship")
+                      .code("common")
+                      .display("Common Law Spouse")
+                      .build()))
+          .build();
+    }
+  }
+}

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
@@ -40,11 +40,12 @@ public class R4CoverageTransformerTest {
             .insTypeSendBillToEmployer(entry("0"))
             .insTypeEsghp(entry("3"))
             .insTypeInsuranceExpirationDate(entry("2021-06-21T15:42:00Z"))
-            .insTypePtRelationshipHipaa(entry("sibling"))
+            .insTypePtRelationshipHipaa(entry("HIPAA 53 LIFE PARTNER"))
             .insTypePharmacyPersonCode(entry("67890"))
             .insTypePatientId(entry("13579"))
             .insTypeSubscriberId(entry("24680"))
             .insTypeEffectiveDateOfPolicy(entry("2021-01-20T21:36:00Z"))
+            .insTypeStopPolicyFromBilling(entry("1"))
             .build();
     assertThat(R4CoverageTransformer.builder().vista(vistaSample).build().toFhir())
         .isEqualTo(
@@ -55,6 +56,21 @@ public class R4CoverageTransformerTest {
                             .url(
                                 "http://va.gov/fhir/StructureDefinition/coverage-pharmacyPersonCode")
                             .valueInteger(67890)
+                            .build(),
+                        Extension.builder()
+                            .url(
+                                "http://va.gov/fhir/StructureDefinition/coverage-stopPolicyFromBilling")
+                            .valueCodeableConcept(
+                                CodeableConcept.builder()
+                                    .coding(
+                                        List.of(
+                                            Coding.builder()
+                                                .system(
+                                                    "http://terminology.hl7.org/ValueSet/v2-0136")
+                                                .code("Y")
+                                                .display("Yes")
+                                                .build()))
+                                    .build())
                             .build()))
                 .subscriberId("24680")
                 .relationship(
@@ -64,6 +80,8 @@ public class R4CoverageTransformerTest {
                                 Coding.builder()
                                     .system(
                                         "http://terminology.hl7.org/CodeSystem/subscriber-relationship")
+                                    .code("common")
+                                    .display("Common Law Spouse")
                                     .build()))
                         .build())
                 .period(

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
@@ -1,0 +1,93 @@
+package gov.va.api.health.vistafhirquery.service.controller.coverage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.api.health.r4.api.datatypes.CodeableConcept;
+import gov.va.api.health.r4.api.datatypes.Coding;
+import gov.va.api.health.r4.api.datatypes.Period;
+import gov.va.api.health.r4.api.elements.Extension;
+import gov.va.api.health.r4.api.elements.Reference;
+import gov.va.api.health.r4.api.resources.Coverage;
+import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsEntry;
+import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsRpcResults;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class R4CoverageTransformerTest {
+  @Test
+  void empty() {
+    assertThat(R4CoverageTransformer.builder().vista(GetInsRpcResults.empty()).build().toFhir())
+        .isEqualTo(Coverage.builder().build());
+  }
+
+  private GetInsEntry entry(String value) {
+    return GetInsEntry.builder()
+        .fileNumber("x")
+        .ien("x")
+        .fieldNumber("x")
+        .internalValueRepresentation(value.toUpperCase())
+        .externalValueRepresentation(value)
+        .build();
+  }
+
+  @Test
+  void toFhir() {
+    var vistaSample =
+        GetInsRpcResults.builder()
+            .insTypeInsuranceType(entry("type"))
+            .insTypeGroupPlan(entry("12345"))
+            .insTypeCoordinationOfBenefits(entry("1"))
+            .insTypeSendBillToEmployer(entry("0"))
+            .insTypeEsghp(entry("3"))
+            .insTypeInsuranceExpirationDate(entry("2021-06-21T15:42:00Z"))
+            .insTypePtRelationshipHipaa(entry("sibling"))
+            .insTypePharmacyPersonCode(entry("67890"))
+            .insTypePatientId(entry("13579"))
+            .insTypeSubscriberId(entry("24680"))
+            .insTypeEffectiveDateOfPolicy(entry("2021-01-20T21:36:00Z"))
+            .build();
+    assertThat(R4CoverageTransformer.builder().vista(vistaSample).build().toFhir())
+        .isEqualTo(
+            Coverage.builder()
+                .extension(
+                    List.of(
+                        Extension.builder()
+                            .url(
+                                "http://va.gov/fhir/StructureDefinition/coverage-pharmacyPersonCode")
+                            .valueInteger(67890)
+                            .build()))
+                .subscriberId("24680")
+                .relationship(
+                    CodeableConcept.builder()
+                        .coding(
+                            List.of(
+                                Coding.builder()
+                                    .system(
+                                        "http://terminology.hl7.org/CodeSystem/subscriber-relationship")
+                                    .build()))
+                        .build())
+                .period(
+                    Period.builder()
+                        .start("2021-01-20T21:36:00Z")
+                        .end("2021-06-21T15:42:00Z")
+                        .build())
+                .payor(List.of(Reference.builder().reference("Coverage/TYPE").build()))
+                .coverageClass(
+                    List.of(
+                        Coverage.CoverageClass.builder()
+                            .value("12345")
+                            .type(
+                                CodeableConcept.builder()
+                                    .coding(
+                                        List.of(
+                                            Coding.builder()
+                                                .system(
+                                                    "http://terminology.hl7.org/CodeSystem/coverage-class")
+                                                .code("group")
+                                                .build()))
+                                    .build())
+                            .build()))
+                .order(1)
+                .build());
+  }
+}

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
@@ -17,7 +17,7 @@ public class R4CoverageTransformerTest {
   @Test
   void empty() {
     assertThat(R4CoverageTransformer.builder().vista(GetInsRpcResults.empty()).build().toFhir())
-        .isEqualTo(Coverage.builder().build());
+        .isEqualTo(Coverage.builder().status(Coverage.Status.active).build());
   }
 
   private GetInsEntry entry(String value) {
@@ -72,6 +72,7 @@ public class R4CoverageTransformerTest {
                                                 .build()))
                                     .build())
                             .build()))
+                .status(Coverage.Status.active)
                 .subscriberId("24680")
                 .relationship(
                     CodeableConcept.builder()

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
@@ -47,7 +47,12 @@ public class R4CoverageTransformerTest {
             .insTypeEffectiveDateOfPolicy(entry("2021-01-20T21:36:00Z"))
             .insTypeStopPolicyFromBilling(entry("1"))
             .build();
-    assertThat(R4CoverageTransformer.builder().vista(vistaSample).build().toFhir())
+    assertThat(
+            R4CoverageTransformer.builder()
+                .patientIcn("1010101010V666666")
+                .vista(vistaSample)
+                .build()
+                .toFhir())
         .isEqualTo(
             Coverage.builder()
                 .extension(
@@ -60,20 +65,11 @@ public class R4CoverageTransformerTest {
                         Extension.builder()
                             .url(
                                 "http://va.gov/fhir/StructureDefinition/coverage-stopPolicyFromBilling")
-                            .valueCodeableConcept(
-                                CodeableConcept.builder()
-                                    .coding(
-                                        List.of(
-                                            Coding.builder()
-                                                .system(
-                                                    "http://terminology.hl7.org/ValueSet/v2-0136")
-                                                .code("Y")
-                                                .display("Yes")
-                                                .build()))
-                                    .build())
+                            .valueBoolean(true)
                             .build()))
                 .status(Coverage.Status.active)
                 .subscriberId("24680")
+                .beneficiary(Reference.builder().reference("Patient/1010101010V666666").build())
                 .relationship(
                     CodeableConcept.builder()
                         .coding(

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
@@ -11,12 +11,17 @@ import gov.va.api.health.r4.api.resources.Coverage;
 import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsEntry;
 import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsRpcResults;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class R4CoverageTransformerTest {
   @Test
   void empty() {
-    assertThat(R4CoverageTransformer.builder().vista(GetInsRpcResults.empty()).build().toFhir())
+    assertThat(
+            R4CoverageTransformer.builder()
+                .rpcResult(Map.entry("666", GetInsRpcResults.empty()))
+                .build()
+                .toFhir())
         .isEqualTo(Coverage.builder().status(Coverage.Status.active).build());
   }
 
@@ -50,7 +55,7 @@ public class R4CoverageTransformerTest {
     assertThat(
             R4CoverageTransformer.builder()
                 .patientIcn("1010101010V666666")
-                .vista(vistaSample)
+                .rpcResult(Map.entry("666", vistaSample))
                 .build()
                 .toFhir())
         .isEqualTo(

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageTransformerTest.java
@@ -2,15 +2,9 @@ package gov.va.api.health.vistafhirquery.service.controller.coverage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import gov.va.api.health.r4.api.datatypes.CodeableConcept;
-import gov.va.api.health.r4.api.datatypes.Coding;
-import gov.va.api.health.r4.api.datatypes.Period;
-import gov.va.api.health.r4.api.elements.Extension;
 import gov.va.api.health.r4.api.elements.Reference;
 import gov.va.api.health.r4.api.resources.Coverage;
-import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsEntry;
 import gov.va.api.lighthouse.charon.models.iblhsamcmsgetins.GetInsRpcResults;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -19,95 +13,27 @@ public class R4CoverageTransformerTest {
   void empty() {
     assertThat(
             R4CoverageTransformer.builder()
-                .rpcResult(Map.entry("666", GetInsRpcResults.empty()))
-                .build()
-                .toFhir())
-        .isEqualTo(Coverage.builder().status(Coverage.Status.active).build());
-  }
-
-  private GetInsEntry entry(String value) {
-    return GetInsEntry.builder()
-        .fileNumber("x")
-        .ien("x")
-        .fieldNumber("x")
-        .internalValueRepresentation(value.toUpperCase())
-        .externalValueRepresentation(value)
-        .build();
-  }
-
-  @Test
-  void toFhir() {
-    var vistaSample =
-        GetInsRpcResults.builder()
-            .insTypeInsuranceType(entry("type"))
-            .insTypeGroupPlan(entry("12345"))
-            .insTypeCoordinationOfBenefits(entry("1"))
-            .insTypeSendBillToEmployer(entry("0"))
-            .insTypeEsghp(entry("3"))
-            .insTypeInsuranceExpirationDate(entry("2021-06-21T15:42:00Z"))
-            .insTypePtRelationshipHipaa(entry("HIPAA 53 LIFE PARTNER"))
-            .insTypePharmacyPersonCode(entry("67890"))
-            .insTypePatientId(entry("13579"))
-            .insTypeSubscriberId(entry("24680"))
-            .insTypeEffectiveDateOfPolicy(entry("2021-01-20T21:36:00Z"))
-            .insTypeStopPolicyFromBilling(entry("1"))
-            .build();
-    assertThat(
-            R4CoverageTransformer.builder()
                 .patientIcn("1010101010V666666")
-                .rpcResult(Map.entry("666", vistaSample))
+                .rpcResult(Map.entry("666", GetInsRpcResults.empty()))
                 .build()
                 .toFhir())
         .isEqualTo(
             Coverage.builder()
-                .extension(
-                    List.of(
-                        Extension.builder()
-                            .url(
-                                "http://va.gov/fhir/StructureDefinition/coverage-pharmacyPersonCode")
-                            .valueInteger(67890)
-                            .build(),
-                        Extension.builder()
-                            .url(
-                                "http://va.gov/fhir/StructureDefinition/coverage-stopPolicyFromBilling")
-                            .valueBoolean(true)
-                            .build()))
+                .id("1010101010V666666^666")
                 .status(Coverage.Status.active)
-                .subscriberId("24680")
                 .beneficiary(Reference.builder().reference("Patient/1010101010V666666").build())
-                .relationship(
-                    CodeableConcept.builder()
-                        .coding(
-                            List.of(
-                                Coding.builder()
-                                    .system(
-                                        "http://terminology.hl7.org/CodeSystem/subscriber-relationship")
-                                    .code("common")
-                                    .display("Common Law Spouse")
-                                    .build()))
-                        .build())
-                .period(
-                    Period.builder()
-                        .start("2021-01-20T21:36:00Z")
-                        .end("2021-06-21T15:42:00Z")
-                        .build())
-                .payor(List.of(Reference.builder().reference("Coverage/TYPE").build()))
-                .coverageClass(
-                    List.of(
-                        Coverage.CoverageClass.builder()
-                            .value("12345")
-                            .type(
-                                CodeableConcept.builder()
-                                    .coding(
-                                        List.of(
-                                            Coding.builder()
-                                                .system(
-                                                    "http://terminology.hl7.org/CodeSystem/coverage-class")
-                                                .code("group")
-                                                .build()))
-                                    .build())
-                            .build()))
-                .order(1)
                 .build());
+  }
+
+  @Test
+  void toFhir() {
+    assertThat(
+            R4CoverageTransformer.builder()
+                .patientIcn("1010101010V666666")
+                .rpcResult(
+                    Map.entry("666", CoverageSamples.VistaIblhsGetInsRpc.create().getInsResults()))
+                .build()
+                .toFhir())
+        .isEqualTo(CoverageSamples.R4.create().coverage());
   }
 }


### PR DESCRIPTION
# [API-8127](https://vajira.max.gov/browse/API-8127)
I _think_ this covers all the direct VistA to Coverage mappings in Jay's spreadsheet. All of Coverage's required fields are populated.