### PR TITLE
API-5557-coverage-read-api

### DIFF
--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/DateSearchBoundaries.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/DateSearchBoundaries.java
@@ -198,7 +198,7 @@ public class DateSearchBoundaries {
   }
 
   private void invalidDateCombination() {
-    ResourceExceptions.BadSearchParameters.because(
+    throw ResourceExceptions.BadSearchParameters.because(
         "Bad date search combination : date=" + date1.toString() + "&" + date2.toString());
   }
 

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Bundler.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Bundler.java
@@ -52,12 +52,12 @@ public class R4Bundler<
     bundle.link(toLinks());
     int page = HttpRequestParameters.integer(request, "page", 1);
     if (page <= 0) {
-      ResourceExceptions.BadSearchParameters.because("page value must be greater than 0");
+      throw ResourceExceptions.BadSearchParameters.because("page value must be greater than 0");
     }
     int count =
         HttpRequestParameters.integer(request, "_count", linkProperties.getDefaultPageSize());
     if (count < 0) {
-      ResourceExceptions.BadSearchParameters.because(
+      throw ResourceExceptions.BadSearchParameters.because(
           "count value must be greater than or equal to 0");
     }
     if (resources.size() > count) {

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Controllers.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Controllers.java
@@ -18,7 +18,7 @@ public class R4Controllers {
   /** Verifies that a list of resources has only one result and returns that result. */
   public static <R> R verifyAndGetResult(List<R> resources, String publicId) {
     if (resources.size() > 1) {
-      ResourceExceptions.ExpectationFailed.because(
+      throw ResourceExceptions.ExpectationFailed.because(
           "Too many results returned. Expected 1 but found %d.", resources.size());
     }
     return resources.stream()

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Controllers.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Controllers.java
@@ -1,0 +1,28 @@
+package gov.va.api.health.vistafhirquery.service.controller;
+
+import gov.va.api.health.ids.client.IdEncoder;
+import gov.va.api.health.vistafhirquery.service.controller.witnessprotection.WitnessProtection;
+import java.util.List;
+
+public class R4Controllers {
+  /** Try to parse a Segmented Vista Identifier, else throw NotFound. */
+  public static SegmentedVistaIdentifier parseOrDie(
+      WitnessProtection witnessProtection, String publicId) {
+    try {
+      return SegmentedVistaIdentifier.unpack(witnessProtection.toPrivateId(publicId));
+    } catch (IdEncoder.BadId | IllegalArgumentException e) {
+      throw ResourceExceptions.NotFound.because("Could not unpack id: " + publicId);
+    }
+  }
+
+  /** Verifies that a list of resources has only one result and returns that result. */
+  public static <R> R verifyAndGetResult(List<R> resources, String publicId) {
+    if (resources.size() > 1) {
+      ResourceExceptions.ExpectationFailed.because(
+          "Too many results returned. Expected 1 but found %d.", resources.size());
+    }
+    return resources.stream()
+        .findFirst()
+        .orElseThrow(() -> ResourceExceptions.NotFound.because(publicId));
+  }
+}

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Controllers.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Controllers.java
@@ -17,6 +17,9 @@ public class R4Controllers {
 
   /** Verifies that a list of resources has only one result and returns that result. */
   public static <R> R verifyAndGetResult(List<R> resources, String publicId) {
+    if (resources == null) {
+      throw ResourceExceptions.NotFound.because(publicId);
+    }
     if (resources.size() > 1) {
       throw ResourceExceptions.ExpectationFailed.because(
           "Too many results returned. Expected 1 but found %d.", resources.size());

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Transformers.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/R4Transformers.java
@@ -157,6 +157,10 @@ public class R4Transformers {
         .pack();
   }
 
+  public static String toResourceId(String patientId, String siteId, String recordId) {
+    return toResourceId(patientId, siteId, null, recordId);
+  }
+
   /** Gets value of a ValueOnlyXmlAttribute if it exists. */
   public static String valueOfValueOnlyXmlAttribute(ValueOnlyXmlAttribute valueOnlyXmlAttribute) {
     if (isBlank(valueOnlyXmlAttribute)) {

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/ResourceExceptions.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/ResourceExceptions.java
@@ -24,7 +24,7 @@ public class ResourceExceptions {
     }
 
     public static BadSearchParameters because(String message) {
-      throw new BadSearchParameters(message);
+      return new BadSearchParameters(message);
     }
   }
 

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/ResourceExceptions.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/ResourceExceptions.java
@@ -23,7 +23,7 @@ public class ResourceExceptions {
       super(message);
     }
 
-    public static void because(String message) {
+    public static BadSearchParameters because(String message) {
       throw new BadSearchParameters(message);
     }
   }
@@ -34,13 +34,13 @@ public class ResourceExceptions {
       super(message);
     }
 
-    public static void because(String message) {
-      throw new ExpectationFailed(message);
+    public static ExpectationFailed because(String message) {
+      return new ExpectationFailed(message);
     }
 
     @FormatMethod
-    public static void because(String message, Object... values) {
-      because(String.format(message, values));
+    public static ExpectationFailed because(String message, Object... values) {
+      return because(String.format(message, values));
     }
   }
 

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/ResourceExceptions.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/ResourceExceptions.java
@@ -12,8 +12,8 @@ public class ResourceExceptions {
       super(message);
     }
 
-    public static void because(String message) {
-      throw new NotFound(message);
+    public static NotFound because(String message) {
+      return new NotFound(message);
     }
   }
 

--- a/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/SegmentedVistaIdentifier.java
+++ b/vista-fhir-query/src/main/java/gov/va/api/health/vistafhirquery/service/controller/SegmentedVistaIdentifier.java
@@ -29,7 +29,7 @@ public class SegmentedVistaIdentifier {
 
   @NonNull String vistaSiteId;
 
-  @NonNull VprGetPatientData.Domains vprRpcDomain;
+  VprGetPatientData.Domains vprRpcDomain;
 
   @NonNull String vistaRecordId;
 
@@ -51,11 +51,9 @@ public class SegmentedVistaIdentifier {
           "The first and third sections of a SegmentedVistaIdentifier must contain "
               + "a type and an identifier value.");
     }
+    // Coverage ids are iens, so any id that doesn't match a domain mapping (L, V) can be ignored
+    // ToDo the above statement may not always hold true as new RPCs/fhir-resources are added.
     var domainType = domainAbbreviationMappings().get(segmentParts[2].charAt(0));
-    if (domainType == null) {
-      throw new IllegalArgumentException(
-          "Identifier value had invalid domain type abbreviation: " + segmentParts[2].charAt(0));
-    }
     return SegmentedVistaIdentifier.builder()
         .patientIdentifierType(PatientIdentifierType.fromAbbreviation(segmentParts[0].charAt(0)))
         .patientIdentifier(segmentParts[0].substring(1))
@@ -82,7 +80,7 @@ public class SegmentedVistaIdentifier {
         "+",
         patientIdentifierType().abbreviation() + patientIdentifier(),
         vistaSiteId(),
-        domainAbbreviationMappings().inverse().get(vprRpcDomain()) + vistaRecordId());
+        domainAbbreviationMappings().inverse().getOrDefault(vprRpcDomain(), '*') + vistaRecordId());
   }
 
   /** The type of a Vista identifier which can be DFN, local ICN, or National ICN. */

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/R4ControllersTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/R4ControllersTest.java
@@ -1,0 +1,59 @@
+package gov.va.api.health.vistafhirquery.service.controller;
+
+import static gov.va.api.health.vistafhirquery.service.controller.R4Controllers.parseOrDie;
+import static gov.va.api.health.vistafhirquery.service.controller.R4Controllers.verifyAndGetResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import gov.va.api.health.vistafhirquery.service.controller.witnessprotection.WitnessProtection;
+import gov.va.api.lighthouse.charon.models.vprgetpatientdata.VprGetPatientData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class R4ControllersTest {
+  @Mock WitnessProtection witnessProtection;
+
+  @Test
+  void parseOrDieUnusableIdReturnsNotFound() {
+    when(witnessProtection.toPrivateId("garbage")).thenReturn("garbage");
+    assertThatExceptionOfType(ResourceExceptions.NotFound.class)
+        .isThrownBy(() -> parseOrDie(witnessProtection, "garbage"));
+  }
+
+  @Test
+  void parseOrDieUsableIdReturnsIdSegment() {
+    // So good! So good! So good!
+    when(witnessProtection.toPrivateId("sweetCaroline")).thenReturn("sNp1+123+V456");
+    var expected =
+        SegmentedVistaIdentifier.builder()
+            .patientIdentifierType(SegmentedVistaIdentifier.PatientIdentifierType.NATIONAL_ICN)
+            .patientIdentifier("p1")
+            .vistaSiteId("123")
+            .vprRpcDomain(VprGetPatientData.Domains.vitals)
+            .vistaRecordId("456")
+            .build();
+    assertThat(parseOrDie(witnessProtection, "sweetCaroline")).isEqualTo(expected);
+  }
+
+  @Test
+  void verifyAndGetResultMoreThanOneResultThrowsExpectationFailed() {
+    assertThatExceptionOfType(ResourceExceptions.ExpectationFailed.class)
+        .isThrownBy(() -> verifyAndGetResult(List.of("1", "2"), "publicId"));
+  }
+
+  @Test
+  void verifyAndGetResultNoResultsThrowsNotFound() {
+    assertThatExceptionOfType(ResourceExceptions.NotFound.class)
+        .isThrownBy(() -> verifyAndGetResult(List.of(), "publicId"));
+  }
+
+  @Test
+  void verifyAndGetResultOneResultReturnsResult() {
+    assertThat(verifyAndGetResult(List.of("1"), "publicId")).isEqualTo("1");
+  }
+}

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/CoverageSamples.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/CoverageSamples.java
@@ -10,6 +10,7 @@ import gov.va.api.health.r4.api.datatypes.Period;
 import gov.va.api.health.r4.api.elements.Extension;
 import gov.va.api.health.r4.api.elements.Reference;
 import gov.va.api.health.r4.api.resources.Coverage;
+import gov.va.api.health.vistafhirquery.service.controller.SegmentedVistaIdentifier;
 import gov.va.api.lighthouse.charon.models.lhslighthouserpcgateway.LhsLighthouseRpcGatewayResponse;
 import java.util.Arrays;
 import java.util.Collection;
@@ -49,12 +50,16 @@ public class CoverageSamples {
     }
 
     LhsLighthouseRpcGatewayResponse.Results getsManifestResults() {
+      return getsManifestResults("1,8,");
+    }
+
+    LhsLighthouseRpcGatewayResponse.Results getsManifestResults(String id) {
       return LhsLighthouseRpcGatewayResponse.Results.builder()
           .results(
               List.of(
                   LhsLighthouseRpcGatewayResponse.FilemanEntry.builder()
                       .file("2.312")
-                      .ien("1,8,")
+                      .ien(id)
                       .fields(fields())
                       .build()))
           .build();
@@ -94,7 +99,15 @@ public class CoverageSamples {
     private List<Coverage.CoverageClass> classes(String station, String patient) {
       return List.of(
           Coverage.CoverageClass.builder()
-              .value(patient + "^" + station + "^87")
+              .value(
+                  SegmentedVistaIdentifier.builder()
+                      .patientIdentifierType(
+                          SegmentedVistaIdentifier.PatientIdentifierType.NATIONAL_ICN)
+                      .patientIdentifier(patient)
+                      .vistaSiteId(station)
+                      .vistaRecordId("87")
+                      .build()
+                      .pack())
               .type(
                   CodeableConcept.builder()
                       .coding(
@@ -108,12 +121,20 @@ public class CoverageSamples {
     }
 
     Coverage coverage() {
-      return coverage("666", "1010101010V666666");
+      return coverage("666", "1,8,", "1010101010V666666");
     }
 
-    Coverage coverage(String station, String patient) {
+    Coverage coverage(String station, String ien, String patient) {
       return Coverage.builder()
-          .id(patient + "^" + station + "^1,8,")
+          .id(
+              SegmentedVistaIdentifier.builder()
+                  .patientIdentifierType(
+                      SegmentedVistaIdentifier.PatientIdentifierType.NATIONAL_ICN)
+                  .patientIdentifier(patient)
+                  .vistaSiteId(station)
+                  .vistaRecordId(ien)
+                  .build()
+                  .pack())
           .extension(extensions())
           .status(Coverage.Status.active)
           .subscriberId("R50797108")
@@ -123,7 +144,16 @@ public class CoverageSamples {
           .payor(
               List.of(
                   Reference.builder()
-                      .reference("Organization/" + patient + "^" + station + "^36;4")
+                      .reference(
+                          "Organization/"
+                              + SegmentedVistaIdentifier.builder()
+                                  .patientIdentifierType(
+                                      SegmentedVistaIdentifier.PatientIdentifierType.NATIONAL_ICN)
+                                  .patientIdentifier(patient)
+                                  .vistaSiteId(station)
+                                  .vistaRecordId("36;4")
+                                  .build()
+                                  .pack())
                       .build()))
           .coverageClass(classes(station, patient))
           .order(1)

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageResponseIncludesIcnHeaderAdviceTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/coverage/R4CoverageResponseIncludesIcnHeaderAdviceTest.java
@@ -54,7 +54,7 @@ public class R4CoverageResponseIncludesIcnHeaderAdviceTest {
                 .entry(
                     List.of(
                         Coverage.Entry.builder()
-                            .resource(CoverageSamples.R4.create().coverage("666", "p1"))
+                            .resource(CoverageSamples.R4.create().coverage("666", "1,8,", "p1"))
                             .build()))
                 .build());
     when(alternatePatientIds.toPublicId(eq("p1"))).thenReturn("p1");
@@ -72,7 +72,7 @@ public class R4CoverageResponseIncludesIcnHeaderAdviceTest {
                 .entry(
                     List.of(
                         Coverage.Entry.builder()
-                            .resource(CoverageSamples.R4.create().coverage("666", "p1"))
+                            .resource(CoverageSamples.R4.create().coverage("666", "1,8,", "p1"))
                             .build()))
                 .build());
     when(alternatePatientIds.toPublicId(eq("p1"))).thenReturn("p99");

--- a/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/observation/R4ObservationControllerTest.java
+++ b/vista-fhir-query/src/test/java/gov/va/api/health/vistafhirquery/service/controller/observation/R4ObservationControllerTest.java
@@ -93,24 +93,6 @@ public class R4ObservationControllerTest {
   }
 
   @Test
-  void readReturnsTooManyResultsFromVista() {
-    var vista = ObservationVitalSamples.Vista.create();
-    VprGetPatientData.Response.Results results = vista.resultsWithLab();
-    when(vlClient.requestForVistaSite(eq("123"), any(VprGetPatientData.Request.class)))
-        .thenReturn(rpcResponse(RpcResponse.Status.OK, "123", xml(results)));
-    when(wp.toPrivateId("public-sNp1+123+V456")).thenReturn("sNp1+123+V456");
-    assertThatExceptionOfType(ResourceExceptions.ExpectationFailed.class)
-        .isThrownBy(() -> controller().read("public-sNp1+123+V456"));
-  }
-
-  @Test
-  void readUnusableIdReturnsNotFound() {
-    when(wp.toPrivateId("garbage")).thenReturn("garbage");
-    assertThatExceptionOfType(ResourceExceptions.NotFound.class)
-        .isThrownBy(() -> controller().read("garbage"));
-  }
-
-  @Test
   void readVitals() {
     var vista = ObservationVitalSamples.Vista.create();
     VprGetPatientData.Response.Results results = vista.results();


### PR DESCRIPTION
# [API-5557](https://vajira.max.gov/browse/API-5557)

This creates the read API for Coverage. I do think we'll want to reevaluate how we create the segmented identifier. My vote would be to allow the controllers to provide extra formats (string would always be included). That way, the responsibility of _how_ to encode would fall to each resource, whereas the segmented identifier itself would become generic and only know about patient id/id type, site id, and vista id.